### PR TITLE
Update dotnet publish options in CI workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -46,7 +46,7 @@ jobs:
         shell: pwsh
 
       - name: Publish
-        run: dotnet publish CPUSetSetter/CPUSetSetter.csproj -c Release /p:DebugType=None /p:DebugSymbols=false /p:FileVersion=${{ env.VERSION }} -o publish/CPUSetSetter
+        run: dotnet publish CPUSetSetter/CPUSetSetter.csproj -c Release /p:DebugType=None /p:DebugSymbols=false /p:FileVersion=${{ env.VERSION }} /p:PublishSingleFile=true /p:PublishTrimmed=false /p:PublishReadyToRun=true /p:SelfContained=false -o publish/CPUSetSetter
 
       - name: Prepare Release
         run: Copy-Item -Path "deploy_scripts\CreateStartupTask.bat" -Destination "publish\CPUSetSetter\"


### PR DESCRIPTION
Added PublishSingleFile, PublishReadyToRun, and other options to the dotnet publish step in the build_and_release workflow to improve deployment configuration.

-> Results in only a small exe and the bat within the zip file, no other files.