### PR TITLE
Fix: Clear selected CPU set when removed

### DIFF
--- a/CPUSetSetter.sln
+++ b/CPUSetSetter.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\build_and_release.yml = .github\workflows\build_and_release.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CPUSetSetterTests", "CPUSetSetterTests\CPUSetSetterTests.csproj", "{4B6A685A-1D0A-4D05-9E2A-6A6772D9B3A4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/CPUSetSetter/CPUSet.cs
+++ b/CPUSetSetter/CPUSet.cs
@@ -134,6 +134,12 @@ namespace CPUSetSetter
             {
                 pEntry.CpuSet = Unset;
             }
+            // If this CPU Set is the currently selected one in the settings, unselect it
+            if (MainWindowViewModel.Instance?.SettingsSelectedCpuSet == this)
+            {
+                MainWindowViewModel.Instance.SettingsSelectedCpuSet = null;
+            }
+
             // Then remove this Set from the config
             HotkeyListener.Instance.RemoveCallback(_hotkeyCallback!);
             Config.Default.CpuSets.Remove(this);

--- a/CPUSetSetterTests/CPUSetSetterTests.csproj
+++ b/CPUSetSetterTests/CPUSetSetterTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CPUSetSetter\CPUSetSetter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CPUSetSetterTests/CPUSetTests.cs
+++ b/CPUSetSetterTests/CPUSetTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CPUSetSetter;
+using System.Windows.Threading;
+using System.Threading;
+
+namespace CPUSetSetterTests
+{
+    [TestClass]
+    public class CPUSetTests
+    {
+        [TestMethod]
+        public void Remove_SelectedCpuSet_ShouldBeNull()
+        {
+            // Arrange
+            var dispatcher = Dispatcher.CurrentDispatcher;
+            var viewModel = new MainWindowViewModel(dispatcher);
+            var cpuSet = new CPUSet("TestSet");
+            Config.Default.CpuSets.Add(cpuSet);
+            viewModel.SettingsSelectedCpuSet = cpuSet;
+
+            // Act
+            cpuSet.Remove();
+
+            // Assert
+            Assert.IsNull(viewModel.SettingsSelectedCpuSet, "SettingsSelectedCpuSet should be null after removing the selected CPUSet.");
+        }
+    }
+}


### PR DESCRIPTION
When a CPUSet is removed, the `MainWindowViewModel.SettingsSelectedCpuSet` was not being cleared, leaving a dangling reference to the removed object. This could cause unpredictable behavior in the UI.

This fix checks if the removed `CPUSet` is the currently selected one and, if so, sets `SettingsSelectedCpuSet` to `null`.

Additionally, a new test case has been added to verify that the `SettingsSelectedCpuSet` is cleared after removing the selected `CPUSet`.