### PR TITLE
Ctrl pauses list

### DIFF
--- a/CPUSetSetter/MainWindow.xaml.cs
+++ b/CPUSetSetter/MainWindow.xaml.cs
@@ -8,7 +8,7 @@ namespace CPUSetSetter
 {
     public partial class MainWindow : Window
     {
-        private readonly MainWindowViewModel viewModel; 
+        private readonly MainWindowViewModel viewModel;
         private bool isCtrlPressed = false;
 
         public MainWindow()
@@ -17,7 +17,7 @@ namespace CPUSetSetter
             DataContext = viewModel;
             InitializeComponent();
 
-            Loaded += (_, _) => logBox.ScrollToEnd(); 
+            Loaded += (_, _) => logBox.ScrollToEnd();
             PreviewKeyDown += MainWindow_PreviewKeyDown;
             PreviewKeyUp += MainWindow_PreviewKeyUp;
         }

--- a/CPUSetSetter/MainWindowViewModel.cs
+++ b/CPUSetSetter/MainWindowViewModel.cs
@@ -190,6 +190,7 @@ namespace CPUSetSetter
                 await Task.Delay(delayTime);
             }
         }
+
         public void PauseListUpdates()
         {
             if (RunningProcessesView != null)

--- a/CPUSetSetter/PausableObservableCollection.cs
+++ b/CPUSetSetter/PausableObservableCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 
+
 namespace CPUSetSetter
 {
     public class PausableObservableCollection<T> : ObservableCollection<T>


### PR DESCRIPTION
Refactor process list to PausableObservableCollection Suppress list notifications and live sorting while Ctrl is held, resume on release -> Improves selection for setting a process’s CPU set. (Behavior like in Windows Taskmanager)