### PR TITLE
Velopack installer / auto update

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -46,37 +46,22 @@ jobs:
         shell: pwsh
 
       - name: Publish normal
-        run: dotnet publish CPUSetSetter/CPUSetSetter.csproj -c Release /p:DebugType=None /p:DebugSymbols=false /p:FileVersion=${{ env.VERSION }} /p:Version=${{ env.VERSION }} /p:SelfContained=false -o publish/CPUSetSetter
-
-      - name: Publish self-contained
-        run: dotnet publish CPUSetSetter/CPUSetSetter.csproj -c Release /p:DebugType=None /p:DebugSymbols=false /p:FileVersion=${{ env.VERSION }} /p:Version=${{ env.VERSION }} /p:PublishSingleFile=true /p:SelfContained=true -o publish/CPUSetSetter_net9_included
+        run: dotnet publish CPUSetSetter/CPUSetSetter.csproj -c Release /p:DebugType=None /p:DebugSymbols=false /p:FileVersion=${{ env.VERSION }} /p:Version=${{ env.VERSION }} /p:SelfContained=true -o publish/CPUSetSetter
 
       - name: Include licenses
         run: |
           dotnet tool install --global nuget-license
           nuget-license -i .\CPUSetSetter\CPUSetSetter.csproj -t -d .\third-party-licenses
-          Copy-Item -Path .\third-party-licenses -Destination .\publish\CPUSetSetter -Recurse
-          Copy-Item -Path .\third-party-licenses -Destination .\publish\CPUSetSetter_net9_included -Recurse
-          Copy-Item -Path .\LICENSE -Destination .\publish\CPUSetSetter\LICENSE.txt
-          Copy-Item -Path .\LICENSE -Destination .\publish\CPUSetSetter_net9_included\LICENSE.txt
-
-      - name: Build installer
-        run: |
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /O".\release_files" /DMyAppVersion=${{ env.VERSION }} .\Installer_script\Installer.iss
-
-      - name: Compress Release files
-        run: |
-          Compress-Archive -Path .\publish\CPUSetSetter -DestinationPath .\release_files\CPUSetSetter.zip
-          Compress-Archive -Path .\publish\CPUSetSetter_net9_included -DestinationPath .\release_files\CPUSetSetter_net9_included.zip
+          Copy-Item -Path .\third-party-licenses -Destination .\publish\CPUSetSetter -Recurse          
+          Copy-Item -Path .\LICENSE -Destination .\publish\CPUSetSetter\LICENSE.txt              
+   
 
       - name: Show Release file hashes
         run: Get-FileHash .\release_files\* | Format-List Algorithm, Path, Hash
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          body: ${{ env.RELEASE_DESC }}
-          files: release_files/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Velopack Release
+        run: |
+          dotnet tool install -g vpk
+          vpk download github --repoUrl https://github.com/${{ github.repository }} --token ${{ secrets.GITHUB_TOKEN }}
+          vpk pack -u CPUSetSetter -v ${{ env.VERSION }} -p .\publish\CPUSetSetter
+          vpk upload github --repoUrl https://github.com/${{ github.repository }} --token ${{ secrets.GITHUB_TOKEN }} --publish --releaseName "CPU Set Setter ${{ env.VERSION }}" --tag ${{ env.RELEASE_TAG }} --releaseNotes "${{ env.RELEASE_DESC }}"

--- a/CPUSetSetter/App.xaml.cs
+++ b/CPUSetSetter/App.xaml.cs
@@ -2,6 +2,7 @@
 using CPUSetSetter.Platforms;
 using CPUSetSetter.TrayIcon;
 using CPUSetSetter.UI;
+using CPUSetSetter.UI.Tabs.Processes;
 using CPUSetSetter.Util;
 using Microsoft.Win32;
 using System.Globalization;
@@ -20,9 +21,15 @@ namespace CPUSetSetter
         private AppTrayIcon? trayIcon;
         private Mutex? singleInstanceMutex;
         private const string mutexName = "CPUSetSetterLock";
+        
+        /// <summary>
+        /// Set in Program.cs from restart argument provided in VersionChecker
+        /// when the app is restarted after an update
+        /// </summary>
+        public string? UpdatedVersion { get; set; }
 
         protected override void OnStartup(StartupEventArgs e)
-        {
+        {            
             // Show unhandled exceptions in an error dialog box
             AddDialogExceptionHandler();
 
@@ -99,6 +106,16 @@ namespace CPUSetSetter
             if (!AppConfig.Instance.StartMinimized)
             {
                 ShowMainWindow();
+            }
+
+            // Show update success message if the app was just updated
+            if (!string.IsNullOrEmpty(UpdatedVersion))
+            {
+                MessageBox.Show(
+                    $"CPU Set Setter has been successfully updated to version {UpdatedVersion}!",
+                    "CPUSetSetter Update Successful",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
             }
         }
 

--- a/CPUSetSetter/CPUSetSetter.csproj
+++ b/CPUSetSetter/CPUSetSetter.csproj
@@ -10,6 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <SatelliteResourceLanguages>none</SatelliteResourceLanguages>
+    <StartupObject>CPUSetSetter.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.10" />
     <PackageReference Include="System.Management" Version="9.0.10" />
     <PackageReference Include="TaskScheduler" Version="2.12.2" />
+    <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
     
   <ItemGroup>

--- a/CPUSetSetter/Program.cs
+++ b/CPUSetSetter/Program.cs
@@ -1,0 +1,24 @@
+using Velopack;
+
+namespace CPUSetSetter
+{
+    internal class Program
+    {
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            VelopackApp.Build().Run();
+
+            App app = new();
+            
+            // Check for new version as an arg after restarting
+            // after an update
+            if (args.Length > 0)
+            {
+                app.UpdatedVersion = args[0];
+            }
+            
+            app.Run();
+        }
+    }
+}

--- a/CPUSetSetter/Themes/Styles.xaml
+++ b/CPUSetSetter/Themes/Styles.xaml
@@ -1,9 +1,10 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:ui="clr-namespace:CPUSetSetter.UI"
-                    xmlns:masks="clr-namespace:CPUSetSetter.UI.Tabs.Masks"
-                    xmlns:rules="clr-namespace:CPUSetSetter.UI.Tabs.Rules"
-                    xmlns:coreuse="clr-namespace:CPUSetSetter.UI.Tabs.Processes.CoreUsage">
+xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+xmlns:ui="clr-namespace:CPUSetSetter.UI"
+xmlns:util="clr-namespace:CPUSetSetter.Util"
+xmlns:masks="clr-namespace:CPUSetSetter.UI.Tabs.Masks"
+xmlns:rules="clr-namespace:CPUSetSetter.UI.Tabs.Rules"
+xmlns:coreuse="clr-namespace:CPUSetSetter.UI.Tabs.Processes.CoreUsage">
 
     <!-- Window Styles -->
     <Style TargetType="Window">
@@ -15,6 +16,7 @@
     <Style TargetType="masks:CreateMaskWindow" BasedOn="{StaticResource {x:Type Window}}"/>
     <Style TargetType="rules:CreateRuleTemplateWindow" BasedOn="{StaticResource {x:Type Window}}"/>
     <Style TargetType="rules:CreateProgramRuleWindow" BasedOn="{StaticResource {x:Type Window}}"/>
+    <Style TargetType="util:ProgressDialog" BasedOn="{StaticResource {x:Type Window}}"/>
 
     <!-- TextBlock Style -->
     <Style TargetType="TextBlock">
@@ -465,6 +467,13 @@
     <!-- Tooltip Style -->
     <Style TargetType="ToolTip">
         <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+    </Style>
+
+    <!-- ProgressBar Style -->
+    <Style TargetType="ProgressBar">
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
+        <Setter Property="BorderThickness" Value="1"/>
     </Style>
 
     <Style TargetType="coreuse:CoreUsageControl">

--- a/CPUSetSetter/UI/ProgressDialog.xaml
+++ b/CPUSetSetter/UI/ProgressDialog.xaml
@@ -1,0 +1,42 @@
+<Window x:Class="CPUSetSetter.Util.ProgressDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Downloading Update"
+        Height="225"
+        Width="400"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Topmost="True">
+    <Grid Margin="20">
+        <StackPanel VerticalAlignment="Top">
+            <TextBlock x:Name="MessageText"
+                       Text="Downloading update..."
+                       FontSize="14"
+                       TextAlignment="Center"                       
+                       Margin="0,0,0,15"/>
+            
+            <ProgressBar x:Name="ProgressBar"
+                         Height="25"
+                         IsIndeterminate="False"
+                         Minimum="0"
+                         Maximum="100"
+                         Value="0"
+                         Margin="0,0,0,15"/>
+            
+            <TextBlock x:Name="ProgressText"
+                       Text="0%"
+                       FontSize="12"
+                       TextAlignment="Center"                       
+                       Margin="0,0,0,15"/>
+            
+            <Button x:Name="CancelButton"
+                    Content="Cancel"
+                    Click="CancelButton_Click"
+                    Padding="10,5"
+                    HorizontalAlignment="Center"
+                    Width="100"            
+                    BorderThickness="1"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CPUSetSetter/UI/ProgressDialog.xaml.cs
+++ b/CPUSetSetter/UI/ProgressDialog.xaml.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace CPUSetSetter.Util
+{
+    /// <summary>
+    /// Progress dialog window for displaying download progress with a cancel button
+    /// </summary>
+    public partial class ProgressDialog : Window
+    {
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        public ProgressDialog(string message, CancellationTokenSource cancellationTokenSource)
+        {
+            _cancellationTokenSource = cancellationTokenSource;
+            InitializeComponent();
+            MessageText.Text = message;
+        }
+
+        public void SetProgress(int percent)
+        {
+            ProgressBar.Value = percent;
+            ProgressText.Text = $"{percent}%";
+        }
+
+        private void CancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            _cancellationTokenSource.Cancel();
+        }
+    }
+}

--- a/CPUSetSetter/Util/FileDownloader.cs
+++ b/CPUSetSetter/Util/FileDownloader.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using CPUSetSetter.UI.Tabs.Processes;
+using Velopack.Sources;
+
+namespace CPUSetSetter.Util
+{
+    /// <summary>
+    /// Default implementation of file downloader using HttpClient
+    /// </summary>
+    public class FileDownloader : Velopack.Sources.IFileDownloader
+    {
+        private static readonly HttpClient _httpClient = new();
+
+        static FileDownloader()
+        {
+            // Set User-Agent header - GitHub requires this
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "CPUSetSetter");
+        }
+
+        public async Task DownloadFile(string url, string targetFile, Action<int> progress, IDictionary<string, string>? headers = null, double timeout = 30, CancellationToken cancelToken = default)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(timeout));
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancelToken);
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        request.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
+                using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token);
+                if (!response.IsSuccessStatusCode)
+                {
+                    WindowLogger.Write($"Download failed with status code: {response.StatusCode}");
+                    response.EnsureSuccessStatusCode();
+                }
+
+                long? totalBytes = response.Content.Headers.ContentLength ?? 0;
+                long downloadedBytes = 0;
+
+                using Stream contentStream = await response.Content.ReadAsStreamAsync();
+                using FileStream fileStream = new(targetFile, FileMode.Create, FileAccess.Write, FileShare.None);
+
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length, linkedCts.Token)) != 0)
+                {
+                    await fileStream.WriteAsync(buffer, 0, bytesRead);
+                    downloadedBytes += bytesRead;
+                    
+                    int progressPercent = totalBytes > 0 ? (int)((downloadedBytes * 100) / totalBytes) : 0;
+                    progress?.Invoke(progressPercent);
+                }
+            }
+            catch (Exception ex)
+            {
+                WindowLogger.Write($"File download failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async Task<byte[]> DownloadBytes(string url, IDictionary<string, string>? headers = null, double timeout = 30)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(timeout));
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        request.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
+                using HttpResponseMessage response = await _httpClient.SendAsync(request, cts.Token);
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsByteArrayAsync(cts.Token);
+            }
+            catch (Exception ex)
+            {
+                WindowLogger.Write($"Download bytes failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async Task<string> DownloadString(string url, IDictionary<string, string>? headers = null, double timeout = 30)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(timeout));
+
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        request.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
+                using HttpResponseMessage response = await _httpClient.SendAsync(request, cts.Token);
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync(cts.Token);
+            }
+            catch (Exception ex)
+            {
+                WindowLogger.Write($"Download string failed: {ex.Message}");
+                throw;
+            }
+        }
+    }
+}

--- a/CPUSetSetter/Util/VersionChecker.cs
+++ b/CPUSetSetter/Util/VersionChecker.cs
@@ -1,12 +1,12 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CPUSetSetter.Config.Models;
 using CPUSetSetter.UI.Tabs.Processes;
 using System.Diagnostics;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Reflection;
-using System.Text.Json;
 using System.Windows;
+using Velopack;
+using Velopack.Sources;
 
 
 namespace CPUSetSetter.Util
@@ -18,17 +18,23 @@ namespace CPUSetSetter.Util
     {
         public static VersionChecker Instance { get; } = new();
 
+        private static readonly string LatestReleaseUrl = "https://github.com/raicovx/CPUSetSetter/releases/latest";
+        
         // The app version is only set in Releases. During development it will be the default 1.0.0.0
         private static Version DevVersion => new(1, 0, 0, 0);
 
         [ObservableProperty]
-        private bool _newVersionAvailable;
+        private UpdateInfo? _newVersionAvailable = null;
 
         [ObservableProperty]
         private string _versionCheckState = "Version check not ran yet";
 
         public Version? AppVersion { get; } = Assembly.GetEntryAssembly()?.GetName().Version;
 
+        private readonly IFileDownloader FileDownloader = new FileDownloader();
+
+        public UpdateManager UpdateManager;
+        
         public string VersionString
         {
             get
@@ -43,7 +49,9 @@ namespace CPUSetSetter.Util
             }
         }
 
-        public VersionChecker() { }
+        public VersionChecker() {
+            UpdateManager = new UpdateManager(new GithubSource("https://github.com/raicovx/CPUSetSetter", null, false, FileDownloader));
+        }
 
         public void RunVersionChecker()
         {
@@ -58,32 +66,66 @@ namespace CPUSetSetter.Util
 
         public static void OpenLatestReleasePage()
         {
-            Process.Start(new ProcessStartInfo { FileName = "https://github.com/SimonvBez/CPUSetSetter/releases/latest", UseShellExecute = true });
+            Process.Start(new ProcessStartInfo { FileName = LatestReleaseUrl, UseShellExecute = true });
         }
 
-        partial void OnNewVersionAvailableChanged(bool value)
+        partial void OnNewVersionAvailableChanged(UpdateInfo? value)
         {
-            if (!value)
+            if (value == null)
                 return;
 
             WindowLogger.Write("A new version of CPU Set Setter is available on GitHub!");
 
             if (AppConfig.Instance.ShowUpdatePopup)
             {
-                App.Current.Dispatcher.InvokeAsync(() =>
-                {
+                App.Current.Dispatcher.InvokeAsync(async () =>
+                {                   
                     MessageBoxResult result = MessageBox.Show(
                         "A new version of CPU Set Setter is available!\n" +
-                        "Would you like to open the Release page now?\n" +
-                        "(Sorry, self-updaters are hard)\n\n" +
+                        "Would you like to install the update now?\n" +
                         "(This popup can be disabled in the Settings tab)",
-                        "New CPU Set Setter update available",
+                        $"New CPU Set Setter update available ({value.TargetFullRelease.Version})",
                         MessageBoxButton.YesNo,
                         MessageBoxImage.Information);
 
                     if (result == MessageBoxResult.Yes)
                     {
-                        OpenLatestReleasePage();
+                        // Bring the main window to foreground if it's minimized in tray
+                        if (App.Current.MainWindow != null)
+                        {
+                            App.Current.MainWindow.Show();
+                            App.Current.MainWindow.WindowState = System.Windows.WindowState.Normal;
+                            App.Current.MainWindow.Activate();
+                        }
+
+                        using var cts = new CancellationTokenSource();
+                        var progressDialog = new ProgressDialog($"Downloading update {value.TargetFullRelease.Version}...", cts);
+                        progressDialog.Owner = App.Current.MainWindow;
+                        progressDialog.Show();
+                        
+                        try
+                        {
+                            await UpdateManager.DownloadUpdatesAsync(value, progress: (percent) =>
+                            {
+                                App.Current.Dispatcher.Invoke(() =>
+                                {
+                                    progressDialog.SetProgress(percent);
+                                });
+                            }, cancelToken: cts.Token);
+
+                            progressDialog.Close();
+                            UpdateManager.ApplyUpdatesAndRestart(value, [value.TargetFullRelease.Version.ToString()]);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            progressDialog.Close();
+                            MessageBox.Show("Update download was cancelled.", "Download Cancelled", MessageBoxButton.OK, MessageBoxImage.Information);
+                        }
+                        catch (Exception ex)
+                        {
+                            progressDialog.Close();
+                            MessageBox.Show($"There was an error downloading the update.", "Download Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                        }
                     }
                 });
             }
@@ -96,74 +138,35 @@ namespace CPUSetSetter.Util
                 TimeSpan nextRetry;
                 try
                 {
-                    string latestReleaseTag = await GetLatestReleaseTag();
-                    if (latestReleaseTag.StartsWith('v'))
+                    UpdateInfo? newUpdate = await UpdateManager.CheckForUpdatesAsync();
+                    if (newUpdate != null)
                     {
-                        Version latestVersion = new(latestReleaseTag[1..]);
-                        if (latestVersion > AppVersion!)
-                        {
-                            NewVersionAvailable = true;
-                            VersionCheckState = $"A new version is available! ({latestReleaseTag})";
-                            return;
-                        }
-                        VersionCheckState = "Currently up-to-date";
-                        nextRetry = TimeSpan.FromHours(24); // No update available. Check again the next day
+                        //there is an update. lets prompt the user to install
+                        NewVersionAvailable = newUpdate;
+                        VersionCheckState = $"A new version is available! ({newUpdate.TargetFullRelease.Version})";
+                        return;
                     }
                     else
                     {
-                        // A response was received, but not in the "vx.x.x" format like expected
-                        VersionCheckState = "Failed to parse latest version";
-                        return;
+                        nextRetry = TimeSpan.FromHours(24); // No update available. Check again the next day                     
+                        VersionCheckState = "Currently up-to-date";
                     }
                 }
-                catch (HttpRequestException)
+                catch (HttpRequestException e)
                 {
                     // Failed to reach GitHub, assume internet is down and try again soon
-                    VersionCheckState = "Version check failed";
+                    VersionCheckState = "Version check failed";                    
                     nextRetry = TimeSpan.FromSeconds(60);
-                }
-                catch (Exception)
+                }               
+                catch (Exception e)
                 {
                     // Any other exception (probably NoSuccessResponseException), assume GitHub doesn't want a request for a while
-                    VersionCheckState = "Version check failed";
+                    VersionCheckState = "Version check failed ";                    
                     nextRetry = TimeSpan.FromHours(24);
                 }
 
                 await Task.Delay(nextRetry);
             }
-        }
-
-        private static async Task<string> GetLatestReleaseTag()
-        {
-            using HttpClient client = new();
-
-            // GitHub API requires a User-Agent header
-            client.DefaultRequestHeaders.UserAgent.Add(
-                new ProductInfoHeaderValue("CPUSetSetterUpdateChecker", "1.0"));
-
-            string url = "https://api.github.com/repos/SimonvBez/CPUSetSetter/releases/latest";
-
-            var response = await client.GetAsync(url);
-            try
-            {
-                response.EnsureSuccessStatusCode();
-            }
-            catch (HttpRequestException)
-            {
-                throw new NoSuccessResponseException();
-            }
-
-            string json = await response.Content.ReadAsStringAsync();
-
-            using var doc = JsonDocument.Parse(json);
-            var root = doc.RootElement;
-
-            if (root.TryGetProperty("tag_name", out JsonElement tagElement))
-            {
-                return tagElement.GetString() ?? throw new NullReferenceException();
-            }
-
-            throw new KeyNotFoundException("tag_name not found in the API response.");
         }
 
         private class NoSuccessResponseException : Exception { }


### PR DESCRIPTION
Didn't see what the last update was when i started working on this, but i got the update message talking about auto updates and figured i could implement that. Velopack seemed like a simple solution and worked nicely with github actions but it has the drawback of not having a wizard and therefore not having a user friendly method of selecting an install location out of the box. Squirrel could be an appropriate alternative to provide auto updates, but i haven't used it in the scope of github actions/releases before.

This might not be the solution you're after since i see you've done some more work on the installer and i kind of undo a lot of that. Also currently there's no check for an existing installation which would mean current users would need to manually remove the existing build. Thought i'd share anyway:

- updates github actions pipeline to output velopack releases json, delta updates and installer as github releases, built as self contained to include the runtime (velopack also outputs a portable version, example release here: https://github.com/raicovx/CPUSetSetter/releases/tag/1.0.18)
- Altered application check for updates flow to use the appropriate source in velopack (https://docs.velopack.io/reference/cs/Velopack/Sources)
- Includes download progress dialog and a success notification once the app restarts after an update

Installation location defaults to a local app data but this can be overridden with a flag: https://docs.velopack.io/reference/cli/content/setup-windows

General documentation here:
https://docs.velopack.io/getting-started/csharp