### PR TITLE
Added Program Rule option to periodically reapply ("Force") a Mask if it was changed externally

### DIFF
--- a/CPUSetSetter/Config/AppConfigFile.cs
+++ b/CPUSetSetter/Config/AppConfigFile.cs
@@ -158,7 +158,7 @@ namespace CPUSetSetter.Config
             List<ProgramRule> programRules = configJson.ProgramRules.Select(jsonProgramRule =>
             {
                 LogicalProcessorMask mask = logicalProcessorMasks.Single(mask => mask.Name == jsonProgramRule.LogicalProcessorMaskName);
-                return new ProgramRule(jsonProgramRule.ProgramPath, mask, true);
+                return new ProgramRule(jsonProgramRule.ProgramPath, mask, jsonProgramRule.AutoReapply, true);
             }).ToList();
 
             // Construct the RuleTemplate models from the config
@@ -240,7 +240,7 @@ namespace CPUSetSetter.Config
 
                 // Convert the ProgramRules models to JSON objects
                 ProgramRules = config.ProgramRules.Select(programRule =>
-                    new ProgramRuleJson(programRule.ProgramPath, programRule.Mask.Name)
+                    new ProgramRuleJson(programRule.ProgramPath, programRule.Mask.Name, programRule.AutoReapply)
                 ).ToList();
 
                 // Convert the RuleTemplates models to JSON objects
@@ -289,18 +289,21 @@ namespace CPUSetSetter.Config
         {
             public string ProgramPath { get; init; }
             public string LogicalProcessorMaskName { get; init; }
+            public bool AutoReapply { get; init; }
 
             [JsonConstructor]
             private ProgramRuleJson()
             {
                 ProgramPath = string.Empty;
                 LogicalProcessorMaskName = string.Empty;
+                AutoReapply = false;
             }
 
-            public ProgramRuleJson(string programPath, string logicalProcessorMaskName)
+            public ProgramRuleJson(string programPath, string logicalProcessorMaskName, bool autoReapply)
             {
                 ProgramPath = programPath;
                 LogicalProcessorMaskName = logicalProcessorMaskName;
+                AutoReapply = autoReapply;
             }
         }
 

--- a/CPUSetSetter/Config/Models/ProgramRule.cs
+++ b/CPUSetSetter/Config/Models/ProgramRule.cs
@@ -12,6 +12,7 @@ namespace CPUSetSetter.Config.Models
     {
         private readonly HashSet<ProcessListEntryViewModel> runningRuleProcesses = [];
         private bool _isSettingMask = false;
+        private bool _isSettingAutoReapply = false;
         private bool _isRemoved = false;
 
         public string ProgramPath { get; }
@@ -24,13 +25,17 @@ namespace CPUSetSetter.Config.Models
         [NotifyPropertyChangedFor(nameof(IsDeviatingFromRuleTemplate))]
         private RuleTemplate? _matchingRuleTemplate;
 
+        [ObservableProperty]
+        private bool _autoReapply;
+
         public bool HasRunningProcesses => runningRuleProcesses.Count >= 1;
         public bool IsDeviatingFromRuleTemplate => MatchingRuleTemplate is not null && MatchingRuleTemplate.Mask != Mask;
 
-        public ProgramRule(string programPath, LogicalProcessorMask mask, bool skipSetup)
+        public ProgramRule(string programPath, LogicalProcessorMask mask, bool autoReapply, bool skipSetup)
         {
             ProgramPath = programPath;
             _mask = mask;
+            _autoReapply = autoReapply;
 
             AddAllRunningProcesses();
             if (!skipSetup)
@@ -85,7 +90,7 @@ namespace CPUSetSetter.Config.Models
             OnPropertyChanged(nameof(HasRunningProcesses));
         }
 
-        public bool SetMask(LogicalProcessorMask newMask, bool shouldRemoveWhenNoMask)
+        public bool SetMask(LogicalProcessorMask newMask, bool shouldAutoRemove)
         {
             if (_isSettingMask)
                 return true; // SetMask was called recursively, probably by OnMaskChanged. Ignore it
@@ -102,10 +107,10 @@ namespace CPUSetSetter.Config.Models
                         allSuccess = false;
                 }
 
-                // When requested, this is a NoMask and there is no matching RuleTemplate, remove this ProgramRule
-                if (shouldRemoveWhenNoMask && newMask.MaskType == MaskApplyType.NoMask && MatchingRuleTemplate is null)
+                // When requested, this is a NoMask, AutoReapply is off, and there is no matching RuleTemplate, remove this ProgramRule
+                if (shouldAutoRemove)
                 {
-                    Remove(false);
+                    TryAutoRemove();
                 }
             }
             finally
@@ -113,6 +118,32 @@ namespace CPUSetSetter.Config.Models
                 _isSettingMask = false;
             }
             return allSuccess;
+        }
+
+        public void SetAutoReapply(bool autoReapply, bool shouldAutoRemove)
+        {
+            if (_isSettingAutoReapply)
+                return;
+
+            _isSettingAutoReapply = true;
+            try
+            {
+                AutoReapply = autoReapply;
+                // Apply the new AutoReapply state to every process of this Program Rule
+                foreach (ProcessListEntryViewModel process in runningRuleProcesses)
+                {
+                    process.AutoReapply = autoReapply;
+                }
+
+                if (shouldAutoRemove)
+                {
+                    TryAutoRemove();
+                }
+            }
+            finally
+            {
+                _isSettingAutoReapply = false;
+            }
         }
 
         /// <summary>
@@ -135,6 +166,18 @@ namespace CPUSetSetter.Config.Models
         }
 
         /// <summary>
+        /// Check if this ProgramRule should be automatically removed, and if so, remove it.
+        /// If the Mask is a NoMark, AutoReapply is off, and there is no matching RuleTemplate, remove this ProgramRule
+        /// </summary>
+        private void TryAutoRemove()
+        {
+            if (Mask.MaskType == MaskApplyType.NoMask && !AutoReapply && MatchingRuleTemplate is null)
+            {
+                Remove(false);
+            }
+        }
+
+        /// <summary>
         /// Set every process to NoMask before removing itself
         /// </summary>
         private void Remove(bool setToNoMask)
@@ -154,6 +197,11 @@ namespace CPUSetSetter.Config.Models
         {
             SetMask(value, false);
             UpdateDeviationStateToRuleTemplate();
+        }
+
+        partial void OnAutoReapplyChanged(bool value)
+        {
+            SetAutoReapply(value, false);
         }
 
         partial void OnMatchingRuleTemplateChanged(RuleTemplate? oldValue, RuleTemplate? newValue)

--- a/CPUSetSetter/Config/Models/ProgramRule.cs
+++ b/CPUSetSetter/Config/Models/ProgramRule.cs
@@ -12,7 +12,6 @@ namespace CPUSetSetter.Config.Models
     {
         private readonly HashSet<ProcessListEntryViewModel> runningRuleProcesses = [];
         private bool _isSettingMask = false;
-        private bool _isSettingAutoReapply = false;
         private bool _isRemoved = false;
 
         public string ProgramPath { get; }
@@ -120,32 +119,6 @@ namespace CPUSetSetter.Config.Models
             return allSuccess;
         }
 
-        public void SetAutoReapply(bool autoReapply, bool shouldAutoRemove)
-        {
-            if (_isSettingAutoReapply)
-                return;
-
-            _isSettingAutoReapply = true;
-            try
-            {
-                AutoReapply = autoReapply;
-                // Apply the new AutoReapply state to every process of this Program Rule
-                foreach (ProcessListEntryViewModel process in runningRuleProcesses)
-                {
-                    process.AutoReapply = autoReapply;
-                }
-
-                if (shouldAutoRemove)
-                {
-                    TryAutoRemove();
-                }
-            }
-            finally
-            {
-                _isSettingAutoReapply = false;
-            }
-        }
-
         /// <summary>
         /// Try to remove itself. Removing is not allowed when there is both a matching RuleTemplate and at least one process of this Rule.
         /// When removing is not allowed, set the Rule processes to the mask of the RuleTemplate.
@@ -201,7 +174,12 @@ namespace CPUSetSetter.Config.Models
 
         partial void OnAutoReapplyChanged(bool value)
         {
-            SetAutoReapply(value, false);
+            AutoReapply = value;
+            // Apply the new AutoReapply state to every process of this Program Rule
+            foreach (ProcessListEntryViewModel process in runningRuleProcesses)
+            {
+                process.AutoReapply = value;
+            }
         }
 
         partial void OnMatchingRuleTemplateChanged(RuleTemplate? oldValue, RuleTemplate? newValue)

--- a/CPUSetSetter/Platforms/IProcessHandler.cs
+++ b/CPUSetSetter/Platforms/IProcessHandler.cs
@@ -11,5 +11,6 @@ namespace CPUSetSetter.Platforms
         /// <returns>Between 0 and 1 on success. -1 on fail</returns>
         double GetAverageCpuUsage();
         bool ApplyMask(LogicalProcessorMask mask);
+        bool ReapplyMask(LogicalProcessorMask mask);
     }
 }

--- a/CPUSetSetter/Platforms/Windows/NativeMethods.cs
+++ b/CPUSetSetter/Platforms/Windows/NativeMethods.cs
@@ -19,7 +19,15 @@ namespace CPUSetSetter.Platforms
 
         [LibraryImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool GetProcessDefaultCpuSets(SafeProcessHandle Process, uint[]? CpuSetIds, uint CpuSetIdCount, ref uint RequiredIdCount);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool SetProcessAffinityMask(SafeProcessHandle hProcess, UIntPtr dwProcessAffinityMask);
+
+        [LibraryImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static partial bool GetProcessAffinityMask(SafeProcessHandle hProcess, ref UIntPtr lpProcessAffinityMask, ref UIntPtr lpSystemAffinityMask);
 
         [LibraryImport("kernel32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/CPUSetSetter/Platforms/Windows/ProcessHandlerWindows.cs
+++ b/CPUSetSetter/Platforms/Windows/ProcessHandlerWindows.cs
@@ -2,7 +2,6 @@
 using CPUSetSetter.UI.Tabs.Processes;
 using Microsoft.Win32.SafeHandles;
 using System.ComponentModel;
-using System.Drawing;
 using System.Runtime.InteropServices;
 
 
@@ -10,7 +9,8 @@ namespace CPUSetSetter.Platforms.Windows
 {
     public class ProcessHandlerWindows : IProcessHandler
     {
-        private readonly static Dictionary<int, uint> _setIdPerLogicalProcessor;
+        private readonly static Dictionary<int, uint> _logicalProcessorToSetId;
+        private readonly static Dictionary<uint, int> _setIdToLogicalProcessor;
         private readonly Queue<CpuTimeTimestamp> _cpuTimeMovingAverageBuffer = new();
 
         private readonly string _executableName;
@@ -22,7 +22,8 @@ namespace CPUSetSetter.Platforms.Windows
 
         static ProcessHandlerWindows()
         {
-            _setIdPerLogicalProcessor = GetCpuSetIdPerLogicalProcessor();
+            _logicalProcessorToSetId = GetCpuSetIdPerLogicalProcessor();
+            _setIdToLogicalProcessor = _logicalProcessorToSetId.ToDictionary(x => x.Value, x => x.Key);
         }
 
         public ProcessHandlerWindows(string executableName, uint pid, SafeProcessHandle queryHandle)
@@ -110,35 +111,57 @@ namespace CPUSetSetter.Platforms.Windows
             return result;
         }
 
+        public bool ReapplyMask(LogicalProcessorMask mask)
+        {
+            if (_previousMaskType != mask.MaskType)
+                return true;
+
+            bool[] actualMask;
+            try
+            {
+                actualMask = mask.MaskType switch
+                {
+                    MaskApplyType.CPUSet => GetCpuSetMask(),
+                    MaskApplyType.Affinity => GetAffinityMask(),
+                    _ => throw new NotImplementedException(),
+                };
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+            catch (Win32Exception)
+            {
+                return false;
+            }
+
+            if (actualMask.SequenceEqual(mask.BoolMask))
+                return true;
+
+            return mask.MaskType switch
+            {
+                MaskApplyType.CPUSet => ApplyCpuSet(mask),
+                MaskApplyType.Affinity => ApplyAffinity(mask),
+                _ => throw new NotImplementedException(),
+            };
+        }
+
         /// <summary>
         /// Apply a given mask as a CPU Set
         /// </summary>
         private bool ApplyCpuSet(LogicalProcessorMask mask)
         {
             int error;
+            string extraHelpString;
 
-            if (_setLimitedInfoHandle is null)
-            {
-                _setLimitedInfoHandle = NativeMethods.OpenProcess(ProcessAccessFlags.PROCESS_SET_LIMITED_INFORMATION, false, _pid);
-                if (_setLimitedInfoHandle.IsInvalid)
-                {
-                    error = Marshal.GetLastWin32Error();
-                    string extraHelpString = (error == 5 && !Environment.IsPrivilegedProcess) ? " Try restarting CPU Set Setter as Admin" : "";
-                    WindowLogger.Write($"ERROR: Could not open process '{_executableName}': {new Win32Exception(error).Message}{extraHelpString}");
-                    return false;
-                }
-            }
-            else if (_setLimitedInfoHandle.IsInvalid)
-            {
-                // The handle was already made previously, don't bother trying again
+            if (!AquireSetLimitedInfoHandle(out SafeProcessHandle setLimitedInfoHandle))
                 return false;
-            }
 
             bool success;
             if (mask.MaskType == MaskApplyType.NoMask)
             {
                 // Clear the CPU Set
-                success = NativeMethods.SetProcessDefaultCpuSets(_setLimitedInfoHandle, null, 0);
+                success = NativeMethods.SetProcessDefaultCpuSets(setLimitedInfoHandle, null, 0);
                 if (success)
                 {
                     WindowLogger.Write($"Cleared CPU Set of '{_executableName}'");
@@ -157,7 +180,7 @@ namespace CPUSetSetter.Platforms.Windows
                 try
                 {
                     if (mask.BoolMask[i])
-                        cpuSetIds.Add(_setIdPerLogicalProcessor[i]);
+                        cpuSetIds.Add(_logicalProcessorToSetId[i]);
                 }
                 catch (KeyNotFoundException)
                 {
@@ -165,7 +188,7 @@ namespace CPUSetSetter.Platforms.Windows
                 }
             }
             uint[] cpuSetIdsArray = cpuSetIds.ToArray();
-            success = NativeMethods.SetProcessDefaultCpuSets(_setLimitedInfoHandle, cpuSetIdsArray, (uint)cpuSetIdsArray.Length);
+            success = NativeMethods.SetProcessDefaultCpuSets(setLimitedInfoHandle, cpuSetIdsArray, (uint)cpuSetIdsArray.Length);
             if (success)
             {
                 WindowLogger.Write($"Applied CPU Set '{mask.Name}' to '{_executableName}'");
@@ -173,31 +196,64 @@ namespace CPUSetSetter.Platforms.Windows
             }
 
             error = Marshal.GetLastWin32Error();
-            string errorMessage = $"ERROR: Could not apply CPU Set to '{_executableName}': {new Win32Exception(error).Message}";
-            if (error == 5)
-                errorMessage += " Likely due to anti-cheat";
-            WindowLogger.Write(errorMessage);
+            extraHelpString = (error == 5 && !Environment.IsPrivilegedProcess) ? " Try restarting CPU Set Setter as Admin" : " Likely due to anti-cheat";
+            WindowLogger.Write($"ERROR: Could not apply CPU Set to '{_executableName}': {new Win32Exception(error).Message}{extraHelpString}");
             return false;
+        }
+
+        private bool[] GetCpuSetMask()
+        {
+            if (_queryLimitedInfoHandle.IsInvalid)
+            {
+                throw new InvalidOperationException("Cannot get process CPU Sets due to invalid handle");
+            }
+
+            uint requiredIdCount = 0;
+            if (!NativeMethods.GetProcessDefaultCpuSets(_queryLimitedInfoHandle, null, 0, ref requiredIdCount))
+            {
+                int error = Marshal.GetLastWin32Error();
+                if (error != 0x7A) // ERROR_INSUFFICIENT_BUFFER
+                    throw new Win32Exception(error);
+            }
+
+            uint[] cpuSetIds = new uint[requiredIdCount];
+            if (!NativeMethods.GetProcessDefaultCpuSets(_queryLimitedInfoHandle, cpuSetIds, (uint)cpuSetIds.Length, ref requiredIdCount))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            bool[] result = new bool[CpuInfo.LogicalProcessorCount];
+            foreach (uint cpuSetId in cpuSetIds)
+            {
+                int logicalProcessor = _setIdToLogicalProcessor[cpuSetId];
+                result[logicalProcessor] = true;
+            }
+            return result;
+        }
+
+        private bool AquireSetLimitedInfoHandle(out SafeProcessHandle setLimitedInfoHandle)
+        {
+            if (_setLimitedInfoHandle is null)
+            {
+                _setLimitedInfoHandle = NativeMethods.OpenProcess(ProcessAccessFlags.PROCESS_SET_LIMITED_INFORMATION, false, _pid);
+                if (_setLimitedInfoHandle.IsInvalid)
+                {
+                    int error = Marshal.GetLastWin32Error();
+                    string extraHelpString = (error == 5 && !Environment.IsPrivilegedProcess) ? " Try restarting CPU Set Setter as Admin" : "";
+                    WindowLogger.Write($"ERROR: Could not open process '{_executableName}': {new Win32Exception(error).Message}{extraHelpString}");
+                }
+            }
+            setLimitedInfoHandle = _setLimitedInfoHandle;
+            return !setLimitedInfoHandle.IsInvalid;
         }
 
         private bool ApplyAffinity(LogicalProcessorMask mask)
         {
-            if (_setInfoHandle is null)
-            {
-                _setInfoHandle = NativeMethods.OpenProcess(ProcessAccessFlags.PROCESS_SET_INFORMATION, false, _pid);
-                if (_setInfoHandle.IsInvalid)
-                {
-                    int error = Marshal.GetLastWin32Error();
-                    string extraHelpString = (error == 5 && !Environment.IsPrivilegedProcess) ? " Try restarting CPU Set Setter as Admin" : " Try a CPU Set Mask instead";
-                    WindowLogger.Write($"ERROR: Could not open process '{_executableName}': {new Win32Exception(error).Message}{extraHelpString}");
-                    return false;
-                }
-            }
-            else if (_setInfoHandle.IsInvalid)
-            {
-                // The handle was already made previously, don't bother trying again
+            int error;
+            string extraHelpString;
+
+            if (!AquireSetInfoHandle(out SafeProcessHandle setInfoHandle))
                 return false;
-            }
 
             bool success;
             if (mask.MaskType == MaskApplyType.NoMask)
@@ -207,44 +263,80 @@ namespace CPUSetSetter.Platforms.Windows
                 {
                     allMask |= (UIntPtr)1 << i;
                 }
-                success = NativeMethods.SetProcessAffinityMask(_setInfoHandle, allMask);
+                success = NativeMethods.SetProcessAffinityMask(setInfoHandle, allMask);
                 if (success)
                 {
                     WindowLogger.Write($"Cleared Affinity of '{_executableName}'");
                     return true;
                 }
-                else
-                {
-                    int error = Marshal.GetLastWin32Error();
-                    WindowLogger.Write($"ERROR: Could not clear Affinity of '{_executableName}': {new Win32Exception(error).Message}");
-                    return false;
-                }
-            }
-            else
-            {
-                UIntPtr bitMask = 0;
-                for (int i = 0; i < mask.BoolMask.Count; ++i)
-                {
-                    if (mask.BoolMask[i])
-                        bitMask |= (UIntPtr)1 << i;
-                }
 
-                success = NativeMethods.SetProcessAffinityMask(_setInfoHandle, bitMask);
-                if (success)
-                {
-                    WindowLogger.Write($"Applied Affinity '{mask.Name}' to '{_executableName}'");
-                    return true;
-                }
-                else
+                error = Marshal.GetLastWin32Error();
+                WindowLogger.Write($"ERROR: Could not clear Affinity of '{_executableName}': {new Win32Exception(error).Message}");
+                return false;
+            }
+
+            UIntPtr bitMask = 0;
+            for (int i = 0; i < mask.BoolMask.Count; ++i)
+            {
+                if (mask.BoolMask[i])
+                    bitMask |= (UIntPtr)1 << i;
+            }
+
+            success = NativeMethods.SetProcessAffinityMask(setInfoHandle, bitMask);
+            if (success)
+            {
+                WindowLogger.Write($"Applied Affinity '{mask.Name}' to '{_executableName}'");
+                return true;
+            }
+
+            error = Marshal.GetLastWin32Error();
+            extraHelpString = (error == 5 && !Environment.IsPrivilegedProcess) ? " Try restarting CPU Set Setter as Admin" : " Likely due to anti-cheat";
+            WindowLogger.Write($"ERROR: Could not apply Affinity to '{_executableName}': {new Win32Exception(error).Message}{extraHelpString}");
+            return false;
+        }
+
+        private bool[] GetAffinityMask()
+        {
+            if (_queryLimitedInfoHandle.IsInvalid)
+            {
+                throw new InvalidOperationException("Cannot get process Affinity due to invalid handle");
+            }
+
+            UIntPtr bitMaskProcess = 0;
+            UIntPtr bitMaskSystem = 0;
+            if (!NativeMethods.GetProcessAffinityMask(_queryLimitedInfoHandle, ref bitMaskProcess, ref bitMaskSystem))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            if (bitMaskProcess == 0)
+            {
+                throw new InvalidOperationException("GetProcessAffinityMask returned a mask of 0");
+            }
+
+            bool[] result = new bool[CpuInfo.LogicalProcessorCount];
+            for (int i = 0; i < result.Length; ++i)
+            {
+                if ((bitMaskProcess & ((UIntPtr)1 << i)) != 0)
+                    result[i] = true;
+            }
+            return result;
+        }
+
+        private bool AquireSetInfoHandle(out SafeProcessHandle setInfoHandle)
+        {
+            if (_setInfoHandle is null)
+            {
+                _setInfoHandle = NativeMethods.OpenProcess(ProcessAccessFlags.PROCESS_SET_INFORMATION, false, _pid);
+                if (_setInfoHandle.IsInvalid)
                 {
                     int error = Marshal.GetLastWin32Error();
-                    string errorMessage = $"ERROR: Could not apply Affinity to '{_executableName}': {new Win32Exception(error).Message}";
-                    if (error == 5)
-                        errorMessage += " Likely due to anti-cheat";
-                    WindowLogger.Write(errorMessage);
-                    return false;
+                    string extraHelpString = (error == 5 && !Environment.IsPrivilegedProcess) ? " Try restarting CPU Set Setter as Admin" : "";
+                    WindowLogger.Write($"ERROR: Could not open process '{_executableName}': {new Win32Exception(error).Message}{extraHelpString}");
                 }
             }
+            setInfoHandle = _setInfoHandle;
+            return !setInfoHandle.IsInvalid;
         }
 
         /// <summary>
@@ -257,7 +349,7 @@ namespace CPUSetSetter.Platforms.Windows
             {
                 int error = Marshal.GetLastWin32Error();
                 if (error != 0x7A) // ERROR_INSUFFICIENT_BUFFER
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                    throw new Win32Exception(error);
             }
 
             Dictionary<int, uint> cpuSets = [];
@@ -276,7 +368,7 @@ namespace CPUSetSetter.Platforms.Windows
                 while (current < bufferEnd)
                 {
                     SYSTEM_CPU_SET_INFORMATION item = Marshal.PtrToStructure<SYSTEM_CPU_SET_INFORMATION>(current);
-                    
+
                     if (item.Type != CPU_SET_INFORMATION_TYPE.CpuSetInformation)
                     {
                         throw new InvalidCastException("Invalid data type encountered; aborting");

--- a/CPUSetSetter/UI/Tabs/Processes/ProcessListEntryViewModel.cs
+++ b/CPUSetSetter/UI/Tabs/Processes/ProcessListEntryViewModel.cs
@@ -17,6 +17,7 @@ namespace CPUSetSetter.UI.Tabs.Processes
         public uint Pid { get; }
         public string Name { get; }
         public string ImagePath { get; }
+        public bool AutoReapply { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(AverageCpuPercentageStr))]
@@ -24,9 +25,6 @@ namespace CPUSetSetter.UI.Tabs.Processes
 
         [ObservableProperty]
         private LogicalProcessorMask _mask;
-
-        [ObservableProperty]
-        private bool _autoReapply;
 
         [ObservableProperty]
         private bool _previousApplyFailed = false;
@@ -46,7 +44,7 @@ namespace CPUSetSetter.UI.Tabs.Processes
             LogicalProcessorMask mask = programRule?.Mask ?? LogicalProcessorMask.NoMask;
             SetMask(mask, false);
             _mask = mask; // _mask is already set by SetMask, this just suppresses a warning
-            _autoReapply = programRule?.AutoReapply ?? false;
+            AutoReapply = programRule?.AutoReapply ?? false;
 
             AverageCpuUsage = _processHandler.GetAverageCpuUsage();
         }
@@ -99,21 +97,6 @@ namespace CPUSetSetter.UI.Tabs.Processes
                 oldValue.MaskChanged -= OnMaskEdited;
             newValue.MaskChanged += OnMaskEdited;
             SetMask(newValue, true);
-        }
-
-        partial void OnAutoReapplyChanged(bool value)
-        {
-            if (ImagePath.Length != 0)
-            {
-                ProgramRule? programRule = RuleHelpers.GetProgramRuleOrNull(ImagePath);
-                if (programRule is null)
-                {
-                    // No ProgramRule exists for this process' ImagePath yet. Create a new ProgramRule
-                    programRule = new(ImagePath, Mask, value, true);
-                    AppConfig.Instance.ProgramRules.Add(programRule);
-                }
-                programRule.SetAutoReapply(value, true);
-            }
         }
 
         private void OnMaskEdited(object? sender, EventArgs e)

--- a/CPUSetSetter/UI/Tabs/Processes/ProcessListEntryViewModel.cs
+++ b/CPUSetSetter/UI/Tabs/Processes/ProcessListEntryViewModel.cs
@@ -26,6 +26,9 @@ namespace CPUSetSetter.UI.Tabs.Processes
         private LogicalProcessorMask _mask;
 
         [ObservableProperty]
+        private bool _autoReapply;
+
+        [ObservableProperty]
         private bool _previousApplyFailed = false;
 
         public string AverageCpuPercentageStr => AverageCpuUsage == -1 ? "" : $"{AverageCpuUsage * 100:F1}%";
@@ -43,6 +46,7 @@ namespace CPUSetSetter.UI.Tabs.Processes
             LogicalProcessorMask mask = programRule?.Mask ?? LogicalProcessorMask.NoMask;
             SetMask(mask, false);
             _mask = mask; // _mask is already set by SetMask, this just suppresses a warning
+            _autoReapply = programRule?.AutoReapply ?? false;
 
             AverageCpuUsage = _processHandler.GetAverageCpuUsage();
         }
@@ -50,6 +54,14 @@ namespace CPUSetSetter.UI.Tabs.Processes
         public void UpdateCpuUsage()
         {
             AverageCpuUsage = _processHandler.GetAverageCpuUsage();
+        }
+
+        public void ReapplyMask()
+        {
+            if (Mask.MaskType == MaskApplyType.NoMask)
+                return;
+
+            PreviousApplyFailed = !_processHandler.ReapplyMask(Mask);
         }
 
         public bool SetMask(LogicalProcessorMask newMask, bool updateRule)
@@ -67,7 +79,8 @@ namespace CPUSetSetter.UI.Tabs.Processes
                 ProgramRule? programRule = RuleHelpers.GetProgramRuleOrNull(ImagePath);
                 if (programRule is null)
                 {
-                    programRule = new(ImagePath, newMask, true);
+                    // No ProgramRule exists for this process' ImagePath yet. Create a new ProgramRule
+                    programRule = new(ImagePath, newMask, false, true);
                     AppConfig.Instance.ProgramRules.Add(programRule);
                 }
                 ruleSuccess = programRule.SetMask(newMask, true);
@@ -86,6 +99,21 @@ namespace CPUSetSetter.UI.Tabs.Processes
                 oldValue.MaskChanged -= OnMaskEdited;
             newValue.MaskChanged += OnMaskEdited;
             SetMask(newValue, true);
+        }
+
+        partial void OnAutoReapplyChanged(bool value)
+        {
+            if (ImagePath.Length != 0)
+            {
+                ProgramRule? programRule = RuleHelpers.GetProgramRuleOrNull(ImagePath);
+                if (programRule is null)
+                {
+                    // No ProgramRule exists for this process' ImagePath yet. Create a new ProgramRule
+                    programRule = new(ImagePath, Mask, value, true);
+                    AppConfig.Instance.ProgramRules.Add(programRule);
+                }
+                programRule.SetAutoReapply(value, true);
+            }
         }
 
         private void OnMaskEdited(object? sender, EventArgs e)

--- a/CPUSetSetter/UI/Tabs/Processes/ProcessesTab.xaml
+++ b/CPUSetSetter/UI/Tabs/Processes/ProcessesTab.xaml
@@ -100,20 +100,6 @@
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
-
-            <!--Force column-->
-            <DataGridTemplateColumn Header="Force"
-                                    CanUserResize="False"
-                                    Width="45">
-                <DataGridTemplateColumn.CellTemplate>
-                    <DataTemplate>
-                        <CheckBox HorizontalAlignment="Center"
-                                  IsChecked="{Binding AutoReapply, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                  ToolTip="Enable to periodically reapply the Mask if it was changed externally">
-                        </CheckBox>
-                    </DataTemplate>
-                </DataGridTemplateColumn.CellTemplate>
-            </DataGridTemplateColumn>
         </DataGrid.Columns>
     </DataGrid>
 

--- a/CPUSetSetter/UI/Tabs/Processes/ProcessesTab.xaml
+++ b/CPUSetSetter/UI/Tabs/Processes/ProcessesTab.xaml
@@ -100,6 +100,20 @@
                     </DataTemplate>
                 </DataGridTemplateColumn.CellTemplate>
             </DataGridTemplateColumn>
+
+            <!--Force column-->
+            <DataGridTemplateColumn Header="Force"
+                                    CanUserResize="False"
+                                    Width="45">
+                <DataGridTemplateColumn.CellTemplate>
+                    <DataTemplate>
+                        <CheckBox HorizontalAlignment="Center"
+                                  IsChecked="{Binding AutoReapply, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  ToolTip="Enable to periodically reapply the Mask if it was changed externally">
+                        </CheckBox>
+                    </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
         </DataGrid.Columns>
     </DataGrid>
 

--- a/CPUSetSetter/UI/Tabs/Processes/ProcessesTabViewModel.cs
+++ b/CPUSetSetter/UI/Tabs/Processes/ProcessesTabViewModel.cs
@@ -38,6 +38,7 @@ namespace CPUSetSetter.UI.Tabs.Processes
             runningProcessesView.Filter = item => ((ProcessListEntryViewModel)item).Name.Contains(ProcessNameFilter, StringComparison.OrdinalIgnoreCase);
 
             Task.Run(ProcessCpuUsageUpdateLoop);
+            Task.Run(ProcessReapplyLoop);
         }
 
         /// <summary>
@@ -145,6 +146,22 @@ namespace CPUSetSetter.UI.Tabs.Processes
                 });
                 int delayTime = windowIsVisible ? 1000 : 5000; // Poll the CPU usage less often when not visible
                 await Task.Delay(delayTime);
+            }
+        }
+
+        private async Task ProcessReapplyLoop()
+        {
+            while (true)
+            {
+                await Task.Delay(15000);
+                await _dispatcher.InvokeAsync(() =>
+                {
+                    foreach (ProcessListEntryViewModel pEntry in RunningProcesses)
+                    {
+                        if (pEntry.AutoReapply)
+                            pEntry.ReapplyMask();
+                    }
+                });
             }
         }
     }

--- a/CPUSetSetter/UI/Tabs/Rules/CreateProgramRuleWindowViewModel.cs
+++ b/CPUSetSetter/UI/Tabs/Rules/CreateProgramRuleWindowViewModel.cs
@@ -37,7 +37,7 @@ namespace CPUSetSetter.UI.Tabs.Rules
         private void CreateProgramRule()
         {
             // Create, add and apply the new ProgramRule
-            ProgramRule programRule = new(RulePath, SelectedMask, false);
+            ProgramRule programRule = new(RulePath, SelectedMask, false, false);
             AppConfig.Instance.ProgramRules.Add(programRule);
             programRule.SetMask(SelectedMask, false);
             CloseWindow();

--- a/CPUSetSetter/UI/Tabs/Rules/RulesTab.xaml
+++ b/CPUSetSetter/UI/Tabs/Rules/RulesTab.xaml
@@ -30,32 +30,32 @@
         </Grid.RowDefinitions>
         
         <DataGrid Grid.Row="0" Margin="0,0,0,10"
-          ItemsSource="{Binding ProgramRules, Source={x:Static config:AppConfig.Instance}}"
-          AutoGenerateColumns="False"
-          RowHeight="24"
-          HeadersVisibility="Column"
-          VerticalScrollBarVisibility="Visible"
-          CanUserReorderColumns="False"
-          CanUserDeleteRows="False"
-          CanUserAddRows="False"
-          CanUserResizeRows="False">
+                  ItemsSource="{Binding ProgramRules, Source={x:Static config:AppConfig.Instance}}"
+                  AutoGenerateColumns="False"
+                  RowHeight="24"
+                  HeadersVisibility="Column"
+                  VerticalScrollBarVisibility="Visible"
+                  CanUserReorderColumns="False"
+                  CanUserDeleteRows="False"
+                  CanUserAddRows="False"
+                  CanUserResizeRows="False">
 
             <DataGrid.Columns>
                 <!--Path column-->
                 <DataGridTextColumn Header="Program Rules"
-                            Binding="{Binding ProgramPath}"
-                            IsReadOnly="True"
-                            Width="*"/>
+                                    Binding="{Binding ProgramPath}"
+                                    IsReadOnly="True"
+                                    Width="*"/>
 
                 <!--Core Mask column-->
                 <DataGridTemplateColumn Header="Core Mask"
-                                IsReadOnly="True"
-                                Width="120"
-                                SortMemberPath="Mask.Name">
+                                        IsReadOnly="True"
+                                        Width="120"
+                                        SortMemberPath="Mask.Name">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <ComboBox ItemsSource="{Binding LogicalProcessorMasks, Source={x:Static config:AppConfig.Instance}}"
-                              SelectedValue="{Binding Mask, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                      SelectedValue="{Binding Mask, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
                                         <TextBlock Text="{Binding Name}"/>
@@ -66,9 +66,24 @@
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
 
+                <!--Force column-->
+                <DataGridTemplateColumn Header="Force"
+                                        CanUserResize="False"
+                                        Width="45">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <CheckBox HorizontalAlignment="Center"
+                                      IsChecked="{Binding AutoReapply, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      ToolTip="Enable to periodically reapply the Mask if it was changed externally">
+                            </CheckBox>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+
                 <!--Action buttons column-->
                 <DataGridTemplateColumn IsReadOnly="True"
-                                Width="54">
+                                        CanUserResize="False"
+                                        Width="54">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
 
@@ -80,10 +95,10 @@
 
                                 <!--Program Rule Reapply button-->
                                 <Button Grid.Column="0"
-                                BorderThickness="0.7"
-                                Command="{Binding DataContext.ProgramRuleReapplyCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                CommandParameter="{Binding}"
-                                ToolTipService.ShowOnDisabled="True">
+                                        BorderThickness="0.7"
+                                        Command="{Binding DataContext.ProgramRuleReapplyCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                        CommandParameter="{Binding}"
+                                        ToolTipService.ShowOnDisabled="True">
 
                                     <!--Disable the Reapply button when the Program Rule is not matching a Rule Template-->
                                     <Button.Style>
@@ -111,10 +126,10 @@
 
                                 <!--Program Rule Remove button-->
                                 <Button Grid.Column="1"
-                                BorderThickness="0.7"
-                                Command="{Binding DataContext.ProgramRuleRemoveCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
-                                CommandParameter="{Binding}"
-                                ToolTipService.ShowOnDisabled="True">
+                                        BorderThickness="0.7"
+                                        Command="{Binding DataContext.ProgramRuleRemoveCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                        CommandParameter="{Binding}"
+                                        ToolTipService.ShowOnDisabled="True">
 
                                     <!--Disable the Remove button when the Program Rule falls under a RuleTemplate AND has an active process-->
                                     <Button.Style>
@@ -158,24 +173,24 @@
 
             <!--Create Program Rule button-->
             <Button Grid.Column="0" Margin="0,0,10,0"
-            Command="{Binding CreateProgramRuleCommand}"
-            Content="Create..."/>
+                    Command="{Binding CreateProgramRuleCommand}"
+                    Content="Create..."/>
 
             <TextBlock Grid.Column="1" Margin="0,0,5,0"
-               VerticalAlignment="Center"
-               Text="Search:"/>
+                       VerticalAlignment="Center"
+                       Text="Search:"/>
 
             <!--Program Rule search bar-->
             <TextBox Grid.Column="2" Margin="0,0,5,0"
-             Text="{Binding ProgramRuleFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                     Text="{Binding ProgramRuleFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
 
             <!--Template-deviating rules only-->
             <CheckBox Grid.Column="3"
-              IsChecked="{Binding ShowOnlyDeviatingProgramRule, UpdateSourceTrigger=PropertyChanged}"/>
+                      IsChecked="{Binding ShowOnlyDeviatingProgramRule, UpdateSourceTrigger=PropertyChanged}"/>
 
             <TextBlock Grid.Column="4"
-               VerticalAlignment="Center"
-               Text="Show only Rules deviating from Templates"/>
+                       VerticalAlignment="Center"
+                       Text="Show only Rules deviating from Templates"/>
         </Grid>
     </Grid>
 

--- a/CPUSetSetter/UI/Tabs/Rules/RulesTabViewModel.cs
+++ b/CPUSetSetter/UI/Tabs/Rules/RulesTabViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CPUSetSetter.Config.Models;
-using CPUSetSetter.Util;
 using System.Windows.Data;
 
 

--- a/CPUSetSetter/Util/RuleHelpers.cs
+++ b/CPUSetSetter/Util/RuleHelpers.cs
@@ -41,7 +41,7 @@ namespace CPUSetSetter.Util
             if (ruleTemplate is not null)
             {
                 // A RuleTemplate exists. Create a new ProgramRule based on it
-                ProgramRule newRule = new(imagePath, ruleTemplate.Mask, true);
+                ProgramRule newRule = new(imagePath, ruleTemplate.Mask, false, true);
                 newRule.MatchingRuleTemplate = ruleTemplate;
                 AppConfig.Instance.ProgramRules.Add(newRule);
                 return newRule;


### PR DESCRIPTION
It is possible for a process' Mask (most commonly Affinity) to be changed externally, either via Task Manager, Process Lasso or the process itself. This would cause the process to run with a different Mask than what was configured in CPU Set Setter.

This PR adds an option to the Program Rules to 'Force' a Mask, meaning CPU Set Setter will check every 15 seconds if it has changed, and if it did, reapply the desired Mask.

I have chosen to make it a per-Program Rule option, rather than a global option to not cause unnecessary CPU strain.

This will provide a more convenient fix for #88 and #86